### PR TITLE
Update link for conformance repo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,4 +27,4 @@
 
 ### Other
 
-- [connect-crosstest](https://github.com/bufbuild/connect-crosstest)
+- [connect-conformance](https://github.com/connectrpc/conformance)

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,4 +27,4 @@
 
 ### Other
 
-- [connect-conformance](https://github.com/connectrpc/conformance)
+- [conformance](https://github.com/connectrpc/conformance)


### PR DESCRIPTION
This updates the link for the conformance repo (fka crosstests).

Note - do not merge until the crosstest repo is moved.