### PR TITLE
Add Rust to the list of repos

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -38,6 +38,10 @@
 
 - [connect-dart](https://github.com/connectrpc/connect-dart)
 
+### Rust
+
+- [connect-rust](https://github.com/connectrpc/connect-rust)
+
 ### Other
 
 - [conformance](https://github.com/connectrpc/conformance)


### PR DESCRIPTION
Adds a Rust section to the organization profile README, linking to [connect-rust](https://github.com/connectrpc/connect-rust).